### PR TITLE
RELION dataset naming fixes: `loads_parameters` -> `just_images` and `exists_ok` -> `exist_ok`

### DIFF
--- a/cryospax/_dataset/relion.py
+++ b/cryospax/_dataset/relion.py
@@ -672,7 +672,7 @@ class RelionParticleDataset(
         mode: Literal["r", "w"] = "r",
         *,
         mrcfile_settings: dict[str, Any] = {},
-        only_images: bool = False,
+        just_images: bool = False,
     ):
         """**Arguments:**
 
@@ -713,7 +713,7 @@ class RelionParticleDataset(
                 for `n_characters = 5` and `prefix = 'f'`.
             - 'overwrite':
                 If `True`, overwrite existing MRC file path if it exists.
-        - `only_images`:
+        - `just_images`:
             If `False`, load parameters and images. Otherwise, load only images.
         """
         # Set properties. First, core properties of the dataset, starting
@@ -730,7 +730,7 @@ class RelionParticleDataset(
         # ... properties common to reading and writing images
         self._path_to_relion_project = pathlib.Path(path_to_relion_project)
         # ... properties for reading images
-        self._only_images = only_images
+        self._just_images = just_images
         # ... properties for writing images
         self._mrcfile_settings = _dict_to_mrcfile_settings(mrcfile_settings)
         # Now, initialize for `mode = 'r'` vs `mode = 'w'`
@@ -776,7 +776,7 @@ class RelionParticleDataset(
             See [`cryospax.RelionParticleParameterFile`][] for more
             information. This key is optional.
         """  # noqa: E501
-        if not self.only_images:
+        if not self.just_images:
             # Load images and parameters. First, read parameters
             # and metadata from the STAR file
             loads_metadata = self.parameter_file.loads_metadata
@@ -1031,21 +1031,21 @@ class RelionParticleDataset(
         self._mrcfile_settings = _dict_to_mrcfile_settings(value)
 
     @property
-    def only_images(self) -> bool:
+    def just_images(self) -> bool:
         """If `True`, load images and *not* parameters. This gives
         better performance when it is not necessary to load parameters.
 
         ```python
-        dataset.only_images = True
+        dataset.just_images = True
         particle_info = dataset[0]
         assert particle_info["parameters"] is None  # True
         ```
         """
-        return self._only_images
+        return self._just_images
 
-    @only_images.setter
-    def only_images(self, value: bool):
-        self._only_images = value
+    @just_images.setter
+    def just_images(self, value: bool):
+        self._just_images = value
 
 
 def _load_starfile_data(

--- a/tests/test_relion_dataset.py
+++ b/tests/test_relion_dataset.py
@@ -476,9 +476,9 @@ def test_no_load_parameters(sample_starfile_path, sample_relion_project_path):
     dataset = RelionParticleDataset(parameter_file, sample_relion_project_path)
 
     # For particle stack with leading dim
-    dataset.only_images = False
+    dataset.just_images = False
     particle_stack_params = dataset[:]
-    dataset.only_images = True
+    dataset.just_images = True
     particle_stack_noparams = dataset[:]
 
     assert particle_stack_noparams["parameters"] is None
@@ -488,9 +488,9 @@ def test_no_load_parameters(sample_starfile_path, sample_relion_project_path):
     assert isinstance(particle_stack_params["images"], np.ndarray)
 
     # For particle stack with no leading dim
-    dataset.only_images = False
+    dataset.just_images = False
     particle_stack_params = dataset[0]
-    dataset.only_images = True
+    dataset.just_images = True
     particle_stack_noparams = dataset[0]
     assert (
         particle_stack_params["images"].shape == particle_stack_noparams["images"].shape

--- a/tests/test_simulate_particles.py
+++ b/tests/test_simulate_particles.py
@@ -233,7 +233,7 @@ def test_load_multiple_mrcs():
     parameters_file = RelionParticleParameterFile(
         path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
         mode="w",
-        exists_ok=True,
+        exist_ok=True,
         options=dict(updates_optics_group=True, loads_envelope=True),
     )
     parameters_file.append(particle_params)


### PR DESCRIPTION
This PR changes `RelionParticleParameterFile.exists_ok` -> `RelionParticleParameterFile.exist_ok` (this is to match the name in `pathlib`) and `RelionParticleDataset.loads_parameters` -> `RelionParticleDataset.just_images`. This is for clarity.