### PR TITLE
Convenience methods for creating and loading datasets: `RelionParticleDataset.empty` and `RelionParticleDataset.load`

### DIFF
--- a/cryospax/_dataset/relion.py
+++ b/cryospax/_dataset/relion.py
@@ -333,19 +333,19 @@ class RelionParticleParameterFile(AbstractRelionParticleParameterFile):
         *,
         exist_ok: bool = False,
         num_particles: int = 0,
-        updates_optics_group: bool = True,
     ) -> Self:
         """Convenience wrapper for
-        [`cryospax.RelionParticleParameterFile.__init__`][] using
-        arguments relevant for `mode = 'w'` and writing parameters
-        via `parameter_file[index] = parameter_info`.
+        [`cryospax.RelionParticleParameterFile.__init__`][] in
+        `mode = 'w'` and writing via
+        `parameter_file[index] = parameter_info` or
+        `parameter_file.append(parameter_info)`.
         """
         return cls(
             path_to_starfile,
             mode="w",
             exist_ok=exist_ok,
             num_particles=num_particles,
-            options={"updates_optics_group": updates_optics_group},
+            options={"updates_optics_group": True},
         )
 
     @classmethod
@@ -354,14 +354,17 @@ class RelionParticleParameterFile(AbstractRelionParticleParameterFile):
         path_to_starfile: str | pathlib.Path,
         *,
         selection_filter: dict[str, Callable] = {},
+        # For loading via `value = dataset[index]`
         loads_metadata: bool = False,
         loads_envelope: bool = False,
         make_image_config: MakeImageConfig = default_make_image_config,
+        # For writing via `dataset[index] = value`
+        updates_optics_group: bool = True,
     ) -> Self:
         """Convenience wrapper for
-        [`cryospax.RelionParticleParameterFile.__init__`][] using
-        arguments relevant for `mode = 'r'` and reading parameters
-        via `parameter_info = parameter_file[index]`
+        [`cryospax.RelionParticleParameterFile.__init__`][] in
+        `mode = 'r'` and reading via `parameter_info = parameter_file[index]`
+        or writing via `parameter_file[index] = parameter_info`.
         """
         return cls(
             path_to_starfile,
@@ -371,6 +374,7 @@ class RelionParticleParameterFile(AbstractRelionParticleParameterFile):
                 "loads_metadata": loads_metadata,
                 "loads_envelope": loads_envelope,
                 "make_image_config": make_image_config,
+                "updates_optics_group": updates_optics_group,
             },
         )
 
@@ -799,12 +803,12 @@ class RelionParticleDataset(
         *,
         exist_ok: bool = False,
         num_particles: int = 0,
-        updates_optics_group: bool = True,
         mrcfile_options: dict[str, Any] = {},
     ) -> Self:
         """Convenience wrapper for intializing a new
         [`cryospax.RelionParticleDataset`][] in `mode = 'w'`
-        and writing via `dataset[index] = particle_info`.
+        and writing via `dataset[index] = particle_info` or
+        `dataset.append(particle_info)`.
 
         See [`cryospax.RelionParticleParameterFile.__init__`][]
         and [`cryospax.RelionParticleDataset.__init__`][]
@@ -814,7 +818,6 @@ class RelionParticleDataset(
             path_to_starfile,
             exist_ok=exist_ok,
             num_particles=num_particles,
-            updates_optics_group=updates_optics_group,
         )
         return cls(
             parameter_file,
@@ -830,14 +833,19 @@ class RelionParticleDataset(
         path_to_relion_project: str | pathlib.Path,
         *,
         selection_filter: dict[str, Callable] = {},
+        # For loading via `value = dataset[index]`
         loads_metadata: bool = False,
         loads_envelope: bool = False,
         make_image_config: MakeImageConfig = default_make_image_config,
         only_images: bool = False,
+        # For writing via `dataset[index] = value`
+        updates_optics_group: bool = True,
+        mrcfile_options: dict[str, Any] = {},
     ) -> Self:
         """Convenience wrapper for loading a
         [`cryospax.RelionParticleDataset`][] in `mode = 'r'`
-        and reading via `particle_info = dataset[index]`.
+        and reading via `particle_info = dataset[index]` or
+        writing via `dataset[index] = particle_info`.
 
         See [`cryospax.RelionParticleParameterFile.__init__`][]
         and [`cryospax.RelionParticleDataset.__init__`][]
@@ -849,9 +857,14 @@ class RelionParticleDataset(
             loads_metadata=loads_metadata,
             loads_envelope=loads_envelope,
             make_image_config=make_image_config,
+            updates_optics_group=updates_optics_group,
         )
         return cls(
-            parameter_file, path_to_relion_project, mode="r", only_images=only_images
+            parameter_file,
+            path_to_relion_project,
+            mode="r",
+            only_images=only_images,
+            mrcfile_options=mrcfile_options,
         )
 
     @override

--- a/docs/api/dataset.md
+++ b/docs/api/dataset.md
@@ -48,6 +48,8 @@ CryoSPAX implements interfaces for reading/writing to common cryo-EM software fr
         group_by_category: false
         members:
             - __init__
+            - load
+            - empty
             - __getitem__
             - __setitem__
             - __len__
@@ -84,6 +86,8 @@ CryoSPAX implements interfaces for reading/writing to common cryo-EM software fr
         group_by_category: false
         members:
             - __init__
+            - load
+            - empty
             - __getitem__
             - __setitem__
             - __len__

--- a/docs/examples/read-dataset.ipynb
+++ b/docs/examples/read-dataset.ipynb
@@ -124,14 +124,12 @@
    ],
    "source": [
     "# Read in the dataset and plot an image\n",
-    "parameter_file = spx.RelionParticleParameterFile(\n",
+    "dataset = spx.RelionParticleDataset.load(\n",
     "    path_to_starfile=\"./data/ribosome_4ug0_particles.star\",\n",
-    "    options=dict(\n",
-    "        loads_metadata=False,  # Set to `True` to load the raw starfile metadata\n",
-    "        loads_envelope=False,  # If `False`, assumes b_factor is 0 and CTF amplitude is 1\n",
-    "    ),\n",
+    "    path_to_relion_project=\"./\",\n",
+    "    loads_metadata=False,  # Set to `True` to load the raw starfile metadata\n",
+    "    loads_envelope=False,  # If `False`, assumes b_factor is 0 and CTF amplitude is 1\n",
     ")\n",
-    "dataset = spx.RelionParticleDataset(parameter_file, path_to_relion_project=\"./\")\n",
     "# ... get the zeroth entry in the STAR file\n",
     "particle_info = dataset[0]\n",
     "eqx.tree_pprint(particle_info)"
@@ -150,18 +148,18 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/37/7n3d9k7903zc8cy1_374smt00000gn/T/ipykernel_35390/3259882216.py:2: FutureWarning: 'normalize_image' is deprecated and has been renamed to 'standardize_image'. The old name will be deprecated in cryoJAX 0.6.0.\n",
-      "  from cryojax.ndimage import normalize_image\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Image mean: 2.8991698e-08 Image standard deviation: 1.0000001\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/37/7n3d9k7903zc8cy1_374smt00000gn/T/ipykernel_49976/3259882216.py:2: FutureWarning: 'normalize_image' is deprecated and has been renamed to 'standardize_image'. The old name will be deprecated in cryoJAX 0.6.0.\n",
+      "  from cryojax.ndimage import normalize_image\n"
      ]
     },
     {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ plugins:
             - numpy.ndarray
             - equinox.Module
             - pandas.DataFrame
+            - cryojax.simulator.BasicImageConfig
     - mkdocstrings:
         handlers:
           python:

--- a/tests/test_relion_dataset.py
+++ b/tests/test_relion_dataset.py
@@ -814,7 +814,6 @@ def test_write_particle_batched_particle_parameters():
     new_parameters_file = RelionParticleParameterFile.empty(
         path_to_starfile="dummy.star",
         exist_ok=True,
-        updates_optics_group=True,
     )
 
     new_parameters_file.path_to_starfile = (
@@ -864,14 +863,12 @@ def test_write_starfile_different_envs():
     new_parameters_file = RelionParticleParameterFile.empty(
         path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
         exist_ok=True,
-        updates_optics_group=True,
     )
 
     particle_params = _make_particle_params(im.FourierConstant(1.0))
     new_parameters_file = RelionParticleParameterFile.empty(
         path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
         exist_ok=True,
-        updates_optics_group=True,
     )
     new_parameters_file.append(particle_params)
     new_parameters_file.save(overwrite=True)
@@ -880,7 +877,6 @@ def test_write_starfile_different_envs():
     new_parameters_file = RelionParticleParameterFile.empty(
         path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
         exist_ok=True,
-        updates_optics_group=True,
     )
     new_parameters_file.append(particle_params)
     new_parameters_file.save(overwrite=True)
@@ -890,7 +886,6 @@ def test_write_starfile_different_envs():
         new_parameters_file = RelionParticleParameterFile.empty(
             path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
             exist_ok=True,
-            updates_optics_group=True,
         )
         new_parameters_file.append(particle_params)
         new_parameters_file.save(overwrite=True)
@@ -1036,7 +1031,6 @@ def test_append_relion_stack_dataset():
         path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
         path_to_relion_project="tests/outputs/starfile_writing/",
         exist_ok=True,
-        updates_optics_group=True,
         mrcfile_options={"overwrite": False},
     )
 

--- a/tests/test_relion_dataset.py
+++ b/tests/test_relion_dataset.py
@@ -811,11 +811,10 @@ def test_write_particle_batched_particle_parameters():
         }
 
     particle_params = _make_particle_params(jnp.array([0, 0, 0, 0, 0]))
-    new_parameters_file = RelionParticleParameterFile(
+    new_parameters_file = RelionParticleParameterFile.empty(
         path_to_starfile="dummy.star",
-        mode="w",
         exist_ok=True,
-        options=dict(updates_optics_group=True, loads_envelope=True),
+        updates_optics_group=True,
     )
 
     new_parameters_file.path_to_starfile = (
@@ -828,10 +827,10 @@ def test_write_particle_batched_particle_parameters():
     with pytest.raises(FileExistsError):
         new_parameters_file.save(overwrite=False)
 
-    parameter_file = RelionParticleParameterFile(
+    parameter_file = RelionParticleParameterFile.load(
         path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
-        mode="r",
-        options=dict(loads_envelope=True, loads_metadata=False),
+        loads_envelope=True,
+        loads_metadata=False,
     )
 
     loaded_params = parameter_file[:]
@@ -862,40 +861,36 @@ def test_write_starfile_different_envs():
         }
 
     particle_params = _make_particle_params(im.FourierGaussian())
-    new_parameters_file = RelionParticleParameterFile(
+    new_parameters_file = RelionParticleParameterFile.empty(
         path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
-        mode="w",
         exist_ok=True,
-        options=dict(updates_optics_group=True, loads_envelope=True),
+        updates_optics_group=True,
     )
 
     particle_params = _make_particle_params(im.FourierConstant(1.0))
-    new_parameters_file = RelionParticleParameterFile(
+    new_parameters_file = RelionParticleParameterFile.empty(
         path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
-        mode="w",
         exist_ok=True,
-        options=dict(updates_optics_group=True, loads_envelope=True),
+        updates_optics_group=True,
     )
     new_parameters_file.append(particle_params)
     new_parameters_file.save(overwrite=True)
 
     particle_params = _make_particle_params(None)
-    new_parameters_file = RelionParticleParameterFile(
+    new_parameters_file = RelionParticleParameterFile.empty(
         path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
-        mode="w",
         exist_ok=True,
-        options=dict(updates_optics_group=True, loads_envelope=True),
+        updates_optics_group=True,
     )
     new_parameters_file.append(particle_params)
     new_parameters_file.save(overwrite=True)
 
     with pytest.raises(ValueError):
         particle_params = _make_particle_params(im.FourierDC(1.0))
-        new_parameters_file = RelionParticleParameterFile(
+        new_parameters_file = RelionParticleParameterFile.empty(
             path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
-            mode="w",
             exist_ok=True,
-            options=dict(updates_optics_group=True, loads_envelope=True),
+            updates_optics_group=True,
         )
         new_parameters_file.append(particle_params)
         new_parameters_file.save(overwrite=True)
@@ -915,10 +910,11 @@ def test_raise_errors_parameter_file(sample_starfile_path):
             mode="CRYOEM",  # type: ignore
             options=dict(loads_envelope=False, loads_metadata=False),
         )
-    parameter_file = RelionParticleParameterFile(
+
+    parameter_file = RelionParticleParameterFile.load(
         path_to_starfile=sample_starfile_path,
-        mode="r",
-        options=dict(loads_envelope=False, loads_metadata=False),
+        loads_envelope=False,
+        loads_metadata=False,
     )
 
     assert parameter_file.mode == "r"
@@ -1036,21 +1032,11 @@ def test_append_relion_stack_dataset():
             "transfer_theory": transfer_theory,
         }
 
-    def _mock_compute_image(particle_parameters, constant_args, per_particle_args):
-        # Mock the image computation
-        return per_particle_args
-
-    new_parameters_file = RelionParticleParameterFile(
+    new_stack = RelionParticleDataset.empty(
         path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
-        mode="w",
-        exist_ok=True,
-        options=dict(updates_optics_group=True, loads_envelope=True),
-    )
-
-    new_stack = RelionParticleDataset(
-        new_parameters_file,
         path_to_relion_project="tests/outputs/starfile_writing/",
-        mode="w",
+        exist_ok=True,
+        updates_optics_group=True,
         mrcfile_options={"overwrite": False},
     )
 


### PR DESCRIPTION
Also creates `RelionParticleParameterFile.empty` and `RelionParticleParameterFile.load`. This makes it easy to create datasets going forward, but the usual API may be needed for advanced usage.

This also includes a small feature addition allowing the creation of empty datasets of a given size via `RelionParticleDataset.empty(..., num_particles=100)`.