### PR TITLE
Fix bug in `empty` method for `RelionParticleParameterFile` for non `none` envelope functions.

### DIFF
--- a/cryospax/_dataset/relion.py
+++ b/cryospax/_dataset/relion.py
@@ -363,6 +363,7 @@ class RelionParticleParameterFile(AbstractRelionParticleParameterFile):
             exist_ok,
             num_particles,
             max_optics_groups,
+            loads_envelope=self._options["loads_envelope"],
         )
         self._starfile_data = starfile_data
         self._num_optics_groups, self._next_optics_group_index = optics_group_info
@@ -376,6 +377,7 @@ class RelionParticleParameterFile(AbstractRelionParticleParameterFile):
         *,
         max_optics_groups: int = 1,
         exist_ok: bool = False,
+        loads_envelope: bool = False,
     ) -> Self:
         """Convenience wrapper for
         [`cryospax.RelionParticleParameterFile.__init__`][] in
@@ -389,6 +391,7 @@ class RelionParticleParameterFile(AbstractRelionParticleParameterFile):
             exist_ok=exist_ok,
             num_particles=num_particles,
             max_optics_groups=max_optics_groups,
+            options=dict(loads_envelope=loads_envelope),
         )
 
     @classmethod
@@ -567,6 +570,14 @@ class RelionParticleParameterFile(AbstractRelionParticleParameterFile):
         particle_data.loc[
             particle_data.index[index], particle_data_for_update.columns
         ] = particle_data_for_update.values
+        if (optics_data["rlnImageSize"].dropna().astype(int) % 2 != 0).any():
+            warnings.warn(
+                "Found odd image size in STAR file. We have observed that odd "
+                "images tend to result in bad reconstructions in Relion, probably "
+                "due to wrong angles and shifts as the conventions might differ "
+                "when the image size is odd. Be careful, and make sure your "
+                "pipeline behaves as expected."
+            )
         self._starfile_data["optics"] = optics_data
         self._starfile_data["particles"] = particle_data
 
@@ -620,6 +631,14 @@ class RelionParticleParameterFile(AbstractRelionParticleParameterFile):
             if len(particle_data) > 0
             else particle_data_to_append
         )
+        if (optics_data["rlnImageSize"].dropna().astype(int) % 2 != 0).any():
+            warnings.warn(
+                "Found odd image size in STAR file. We have observed that odd "
+                "images tend to result in bad reconstructions in Relion, probably "
+                "due to wrong angles and shifts as the conventions might differ "
+                "when the image size is odd. Be careful, and make sure your "
+                "pipeline behaves as expected."
+            )
         self._starfile_data["optics"] = optics_data
         self._starfile_data["particles"] = particle_data
 
@@ -1339,6 +1358,7 @@ def _load_starfile_data(
     exist_ok: bool,
     num_particles: int,
     max_optics_groups: int | None,
+    loads_envelope: bool,
 ) -> tuple[_StarfileData, tuple[int, int]]:
     if mode == "r":
         if path_to_starfile.exists():
@@ -1363,6 +1383,17 @@ def _load_starfile_data(
             if max_optics_groups is None:
                 max_optics_groups = 2 * num_optics_groups
             starfile_data["optics"] = optics_data.reindex(index=range(max_optics_groups))
+
+            if (
+                starfile_data["optics"]["rlnImageSize"].dropna().astype(int) % 2 != 0
+            ).any():
+                warnings.warn(
+                    "Found odd image size in STAR file. We have observed that odd "
+                    "images tend to result in bad reconstructions in Relion, probably "
+                    "due to wrong angles and shifts as the conventions might differ "
+                    "when the image size is odd. Be careful, and make sure your "
+                    "pipeline behaves as expected."
+                )
         else:
             raise FileNotFoundError(
                 f"Set `mode = '{mode}'`, but STAR file {str(path_to_starfile)} does not "
@@ -1382,6 +1413,12 @@ def _load_starfile_data(
                 max_optics_group_index = 1
                 if max_optics_groups is None:
                     max_optics_groups = 1
+
+                relion_particle_entries = (
+                    RELION_SUPPORTED_PARTICLE_ENTRIES
+                    if loads_envelope
+                    else RELION_DEFAULT_PARTICLE_ENTRIES
+                )
                 starfile_data = dict(
                     optics=pd.DataFrame(
                         data={
@@ -1392,7 +1429,7 @@ def _load_starfile_data(
                     particles=pd.DataFrame(
                         data={
                             column: pd.Series(dtype=dtype, index=range(num_particles))
-                            for column, dtype in RELION_DEFAULT_PARTICLE_ENTRIES
+                            for column, dtype in relion_particle_entries
                         }
                     ),
                 )

--- a/tests/test_relion_dataset.py
+++ b/tests/test_relion_dataset.py
@@ -444,6 +444,7 @@ def test_no_load_parameters(sample_starfile_path, sample_relion_project_path):
 #
 
 
+@pytest.mark.parametrize("shape", [(4, 4), (5, 5)])
 @pytest.mark.parametrize(
     "index, loads_envelope",
     [
@@ -452,14 +453,14 @@ def test_no_load_parameters(sample_starfile_path, sample_relion_project_path):
         (0, True),
     ],
 )
-def test_append_particle_parameters(index, loads_envelope):
+def test_append_particle_parameters(index, loads_envelope, shape):
     index = np.asarray(index)
     ndim = index.ndim
 
     @eqx.filter_vmap
     def make_particle_params(_):
         image_config = cxs.BasicImageConfig(
-            shape=(4, 4),
+            shape=shape,
             pixel_size=1.5,
             voltage_in_kilovolts=300.0,
         )
@@ -514,6 +515,7 @@ def test_append_particle_parameters(index, loads_envelope):
     assert compare_dicts(loaded_particle_params, particle_params)
 
 
+@pytest.mark.parametrize("shape", [(4, 4), (5, 5)])
 @pytest.mark.parametrize(
     "index, sets_envelope",
     [
@@ -527,6 +529,7 @@ def test_set_particle_parameters(
     sample_starfile_path,
     index,
     sets_envelope,
+    shape,
 ):
     index = np.asarray(index)
     n_particles, ndim = index.size, index.ndim
@@ -539,7 +542,7 @@ def test_set_particle_parameters(
         pose = make_pose(rng_keys)
         return dict(
             image_config=cxs.BasicImageConfig(
-                shape=(4, 4), pixel_size=3.324, voltage_in_kilovolts=121.3
+                shape=shape, pixel_size=3.324, voltage_in_kilovolts=121.3
             ),
             pose=pose,
             transfer_theory=cxs.ContrastTransferTheory(
@@ -576,7 +579,11 @@ def test_set_particle_parameters(
     parameter_file.particle_data["rlnMicrographName"] = pd.Series(dtype=str)
     parameter_file.particle_data["rlnCoordinateX"] = pd.Series(dtype="Int64")
     parameter_file.particle_data["rlnCoordinateY"] = pd.Series(dtype="Int64")
-    parameter_file[index] = new_parameters
+    if shape[0] % 2 != 0:
+        with pytest.warns(UserWarning, match="odd image size"):
+            parameter_file[index] = new_parameters
+    else:
+        parameter_file[index] = new_parameters
     # Make sure custom metadata was added
     particle_dataframe = parameter_file.particle_data
     assert set(metadata.columns).issubset(particle_dataframe.columns)
@@ -824,70 +831,56 @@ def test_write_particle_batched_particle_parameters():
     return
 
 
-def test_write_starfile_different_envs():
-    def _make_particle_params(envelope):
-        image_config = cxs.BasicImageConfig(
-            shape=(4, 4),
-            pixel_size=1.5,
-            voltage_in_kilovolts=300.0,
-        )
-
-        pose = cxs.EulerAnglePose()
-        transfer_theory = cxs.ContrastTransferTheory(
-            ctf=cxs.AstigmaticCTF(),
-            envelope=envelope,
-        )
-        return {
-            "image_config": image_config,
-            "pose": pose,
-            "transfer_theory": transfer_theory,
-        }
-
-    particle_params = _make_particle_params(im.FourierGaussian())
-    new_parameters_file = RelionParticleParameterFile.empty(
-        path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
-        exist_ok=True,
-        num_particles=0,
-        max_optics_groups=1,
+def _make_particle_params(envelope):
+    image_config = cxs.BasicImageConfig(
+        shape=(4, 4),
+        pixel_size=1.5,
+        voltage_in_kilovolts=300.0,
     )
-    new_parameters_file.append(particle_params)
+    pose = cxs.EulerAnglePose()
+    transfer_theory = cxs.ContrastTransferTheory(
+        ctf=cxs.AstigmaticCTF(),
+        envelope=envelope,
+    )
+    return {
+        "image_config": image_config,
+        "pose": pose,
+        "transfer_theory": transfer_theory,
+    }
+
+
+@pytest.mark.parametrize(
+    "envelope,loads_envelope",
+    [
+        (im.FourierGaussian(), True),
+        (im.FourierConstant(1.0), True),
+        (None, False),
+    ],
+)
+def test_write_starfile_different_envs(envelope, loads_envelope, tmp_path):
+    particle_params = _make_particle_params(envelope)
+    new_parameters_file = RelionParticleParameterFile.empty(
+        path_to_starfile=tmp_path / "test_particle_parameters.star",
+        exist_ok=True,
+        num_particles=1,
+        max_optics_groups=1,
+        loads_envelope=loads_envelope,
+    )
+    new_parameters_file[0] = particle_params
     new_parameters_file.save(overwrite=True)
 
-    particle_params = _make_particle_params(im.FourierConstant(1.0))
-    new_parameters_file = RelionParticleParameterFile.empty(
-        path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
-        exist_ok=True,
-        num_particles=0,
-        max_optics_groups=1,
-    )
-    new_parameters_file.append(particle_params)
-    new_parameters_file.save(overwrite=True)
 
-    particle_params = _make_particle_params(None)
-    new_parameters_file = RelionParticleParameterFile.empty(
-        path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
-        exist_ok=True,
-        num_particles=0,
-        max_optics_groups=1,
-    )
-    new_parameters_file.append(particle_params)
-    new_parameters_file.save(overwrite=True)
-
+def test_write_starfile_unsupported_envelope(tmp_path):
     with pytest.raises(ValueError):
         particle_params = _make_particle_params(im.FourierDC(1.0))
         new_parameters_file = RelionParticleParameterFile.empty(
-            path_to_starfile="tests/outputs/starfile_writing/test_particle_parameters.star",
+            path_to_starfile=tmp_path / "test_particle_parameters.star",
             exist_ok=True,
             num_particles=0,
             max_optics_groups=1,
         )
         new_parameters_file.append(particle_params)
         new_parameters_file.save(overwrite=True)
-
-    # Clean up
-    shutil.rmtree("tests/outputs/starfile_writing/")
-
-    return
 
 
 def test_raise_errors_parameter_file(sample_starfile_path):

--- a/tests/test_simulate_particles.py
+++ b/tests/test_simulate_particles.py
@@ -206,11 +206,12 @@ def test_write_single_image(sample_starfile_path):
     return
 
 
-def test_load_multiple_mrcs():
+@pytest.mark.parametrize("shape", [(4, 4), (5, 5)])
+def test_load_multiple_mrcs(shape):
     @partial(eqx.filter_vmap, in_axes=(0), out_axes=eqx.if_array(0))
     def _make_particle_params(dummy_idx):
         image_config = cxs.BasicImageConfig(
-            shape=(4, 4),
+            shape=shape,
             pixel_size=1.5,
             voltage_in_kilovolts=300.0,
         )
@@ -236,7 +237,11 @@ def test_load_multiple_mrcs():
         exist_ok=True,
         options=dict(loads_envelope=True),
     )
-    parameters_file.append(particle_params)
+    if shape[0] % 2 != 0:
+        with pytest.warns(UserWarning, match="odd image size"):
+            parameters_file.append(particle_params)
+    else:
+        parameters_file.append(particle_params)
 
     n_images = len(parameters_file)
     # print(f"Number of images: {n_images}")


### PR DESCRIPTION
- Fixes error when writing `RelionParticleParameterFile` after instantiation with `empty` using `__setitem__` in the case when the envelope function in the given `transfer_theory` parameter is not `None`. The fix is to set an additional argument when calling `empty`, specifying whether to include the envelope function.

Additional changes:

- Adds a warning when reading or writing `RelionParticleParameterFile` with an odd box size.